### PR TITLE
Set the generateName property in the preconfigured job manifest

### DIFF
--- a/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
+++ b/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
@@ -43,7 +43,10 @@ manifest:
   apiVersion: batch/v1
   kind: Job
   metadata:
-    name: run-pulumi
+    # As of Spinnaker v1.22 to have a unique suffix appended to the job name,
+    # we must set the generatedName property instead of name.
+    # Ref: https://spinnaker.io/community/releases/versions/1-22-4-changelog#breaking-change-suffix-no-longer-added-to-jobs-created-by-kuber
+    generatedName: run-pulumi
     # Will be overridden by the namespace the user selects from the UI.
     namespace: fakenamespace
   spec:

--- a/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
+++ b/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
@@ -46,7 +46,7 @@ manifest:
     # As of Spinnaker v1.22 to have a unique suffix appended to the job name,
     # we must set the generatedName property instead of name.
     # Ref: https://spinnaker.io/community/releases/versions/1-22-4-changelog#breaking-change-suffix-no-longer-added-to-jobs-created-by-kuber
-    generatedName: run-pulumi
+    generateName: run-pulumi
     # Will be overridden by the namespace the user selects from the UI.
     namespace: fakenamespace
   spec:

--- a/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
+++ b/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
@@ -44,8 +44,10 @@ manifest:
   kind: Job
   metadata:
     # As of Spinnaker v1.22 to have a unique suffix appended to the job name,
-    # we must set the generatedName property instead of name.
-    # Ref: https://spinnaker.io/community/releases/versions/1-22-4-changelog#breaking-change-suffix-no-longer-added-to-jobs-created-by-kuber
+    # we must set the generateName property instead of name.
+    # Refs:
+    # https://spinnaker.io/community/releases/versions/1-22-4-changelog#breaking-change-suffix-no-longer-added-to-jobs-created-by-kuber
+    # https://kubernetes.io/docs/reference/using-api/api-concepts/#generated-values
     generateName: run-pulumi
     # Will be overridden by the namespace the user selects from the UI.
     namespace: fakenamespace


### PR DESCRIPTION
Fixes #8.

As detailed in the linked issue, the job name in Spinnaker v1.22+ will no longer have a unique suffix unless `generateName` is used instead of `name` in the job manifest.