### PR TITLE
Place the Pulumi command args env var after the command instead of before

### DIFF
--- a/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
+++ b/pulumi-orca/src/main/resources/com/pulumi/plugin/preconfigured/pulumi.yaml
@@ -60,7 +60,7 @@ manifest:
           - name: pulumi
             image: pulumi/pulumi:latest
             command: ["/bin/sh"]
-            args: ["-c", "pulumi version && git clone $(GIT_REPO_URL) $(WORKING_DIR) && cd $(WORKING_DIR) && $(RESTORE_CMD) && pulumi login $(PULUMI_BACKEND_URL) && pulumi $(PULUMI_COMMAND_ARGS) $(PULUMI_COMMAND)"]
+            args: ["-c", "pulumi version && git clone $(GIT_REPO_URL) $(WORKING_DIR) && cd $(WORKING_DIR) && $(RESTORE_CMD) && pulumi login $(PULUMI_BACKEND_URL) && pulumi $(PULUMI_COMMAND) $(PULUMI_COMMAND_ARGS)"]
             env:
               - name: GIT_REPO_URL
                 value: fakevalue


### PR DESCRIPTION
This was actually the original position for the args env var but in a previous PR I moved it to be _before_ the command. It seems to cause problems when multiple args are passed in the stage input.