### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
       - name: get project info
         id: get_project_info
         run: |
-          echo ::set-output name=PROJECT::$(basename `pwd`)
-          echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-          echo ::set-output name=REPO::${GITHUB_REPOSITORY}
+          echo PROJECT=$(basename `pwd`) >> "$GITHUB_OUTPUT"
+          echo VERSION=${GITHUB_REF/refs\/tags\//} >> "$GITHUB_OUTPUT"
+          echo REPO=${GITHUB_REPOSITORY} >> "$GITHUB_OUTPUT"
       - name: create release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter