### PR TITLE
Bump deprecated artifact actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: build
         run: ./gradlew releaseBundle
       - name: archive build artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: build/distributions


### PR DESCRIPTION
GitHub deprecated `actions/upload-artifact@v1` and the workflow now fails CI on every run. These changes update the action reference to v4. The single artifact upload (`dist`) keeps a unique name, so no v3-to-v4 naming-uniqueness issues apply.

This unblocks #45.